### PR TITLE
Discovery Timeout adjustment

### DIFF
--- a/app/src/main/java/com/niehusst/partyq/services/CommunicationService.kt
+++ b/app/src/main/java/com/niehusst/partyq/services/CommunicationService.kt
@@ -43,7 +43,7 @@ object CommunicationService {
         Manifest.permission.ACCESS_FINE_LOCATION
     )
 
-    private const val TIMEOUT_DISCOVERY_MILLIS = 20000L //TODO: more???? still dont find it in time sometimes
+    private const val TIMEOUT_DISCOVERY_MILLIS = 20000L
     private const val TIMEOUT_INTERVAL_MILLIS = 1000L
     private var discoveryTimer: CountDownTimer? = null
 

--- a/app/src/main/java/com/niehusst/partyq/services/CommunicationService.kt
+++ b/app/src/main/java/com/niehusst/partyq/services/CommunicationService.kt
@@ -43,7 +43,7 @@ object CommunicationService {
         Manifest.permission.ACCESS_FINE_LOCATION
     )
 
-    private const val TIMEOUT_DISCOVERY_MILLIS = 20000L
+    private const val TIMEOUT_DISCOVERY_MILLIS = 20000L //TODO: more???? still dont find it in time sometimes
     private const val TIMEOUT_INTERVAL_MILLIS = 1000L
     private var discoveryTimer: CountDownTimer? = null
 

--- a/app/src/main/java/com/niehusst/partyq/ui/partyJoin/PartyJoinFragment.kt
+++ b/app/src/main/java/com/niehusst/partyq/ui/partyJoin/PartyJoinFragment.kt
@@ -42,18 +42,7 @@ class PartyJoinFragment : Fragment() {
         binding.loading = false
 
         observeConnectionStatus()
-
-        binding.submitButton.setOnClickListener {
-            val codeLongEnough = viewModel.connectToParty(binding.codeEditText.text.toString())
-
-            if (!codeLongEnough) {
-                Toast.makeText(
-                    requireContext(),
-                    R.string.party_code_too_short_message,
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-        }
+        setClickListeners()
     }
 
     override fun onStart() {
@@ -70,6 +59,24 @@ class PartyJoinFragment : Fragment() {
         super.onStop()
         // stop discovery, if it hasn't already stopped by this point
         CommunicationService.stopSearchingForParty()
+    }
+
+    private fun setClickListeners() {
+        binding.submitButton.setOnClickListener {
+            val codeLongEnough = viewModel.connectToParty(binding.codeEditText.text.toString())
+
+            if (!codeLongEnough) {
+                Toast.makeText(
+                    requireContext(),
+                    R.string.party_code_too_short_message,
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        }
+
+        binding.stopButton.setOnClickListener {
+            CommunicationService.stopSearchingForParty()
+        }
     }
 
     private fun observeConnectionStatus() {

--- a/app/src/main/java/com/niehusst/partyq/ui/partyJoin/PartyJoinFragment.kt
+++ b/app/src/main/java/com/niehusst/partyq/ui/partyJoin/PartyJoinFragment.kt
@@ -33,7 +33,7 @@ class PartyJoinFragment : Fragment() {
     ): View? {
         binding = PartyJoinFragmentBinding.inflate(inflater)
         // start comms service so guests can use it to connect to host
-        CommunicationService.start(requireContext())
+        viewModel.startCommunicationService(requireContext())
         return binding.root
     }
 
@@ -58,12 +58,12 @@ class PartyJoinFragment : Fragment() {
     override fun onStop() {
         super.onStop()
         // stop discovery, if it hasn't already stopped by this point
-        CommunicationService.stopSearchingForParty()
+        viewModel.stopSearchingForParty()
     }
 
     private fun setClickListeners() {
         binding.submitButton.setOnClickListener {
-            val codeLongEnough = viewModel.connectToParty(binding.codeEditText.text.toString())
+            val codeLongEnough = viewModel.searchForParty(binding.codeEditText.text.toString())
 
             if (!codeLongEnough) {
                 Toast.makeText(
@@ -75,7 +75,7 @@ class PartyJoinFragment : Fragment() {
         }
 
         binding.stopButton.setOnClickListener {
-            CommunicationService.stopSearchingForParty()
+            viewModel.stopSearchingForParty()
         }
     }
 

--- a/app/src/main/java/com/niehusst/partyq/ui/partyJoin/PartyJoinViewModel.kt
+++ b/app/src/main/java/com/niehusst/partyq/ui/partyJoin/PartyJoinViewModel.kt
@@ -10,17 +10,26 @@ class PartyJoinViewModel : ViewModel() {
 
     var lastCode: String = ""
 
+    fun startCommunicationService(context: Context) {
+        CommunicationService.start(context)
+    }
+
     /**
      * Begins connection discovery.
-     * Returns false to indicate problem with code length.
+     *
+     * @return - false to indicate problem with code length, else true when discovery has started
      */
-    fun connectToParty(code: String): Boolean {
+    fun searchForParty(code: String): Boolean {
         if (code.length != 4) {
             return false
         }
         lastCode = code
         CommunicationService.connectToParty(code)
         return true
+    }
+
+    fun stopSearchingForParty() {
+        CommunicationService.stopSearchingForParty()
     }
 
     fun setGuestData(context: Context) {

--- a/app/src/main/res/layout/party_join_fragment.xml
+++ b/app/src/main/res/layout/party_join_fragment.xml
@@ -102,12 +102,25 @@
         </androidx.cardview.widget.CardView>
 
         <include
+            android:id="@+id/include"
             layout="@layout/loading_spinner"
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             app:progressText="@{@string/searching_for_party}"
+            isGone="@{!loading}" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/stop_button"
+            style="@style/PartyqButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/mediumPadding"
+            android:text="@string/stop_searching"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             isGone="@{!loading}" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/party_join_fragment.xml
+++ b/app/src/main/res/layout/party_join_fragment.xml
@@ -116,6 +116,7 @@
             style="@style/PartyqButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:paddingHorizontal="@dimen/hugePadding"
             android:layout_marginBottom="@dimen/mediumPadding"
             android:text="@string/stop_searching"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,7 @@
     <string name="party_code_too_short_message">Code must be 4 digits</string>
     <string name="searching_for_party">Searching for Party…</string>
     <string name="party_not_found">Party not found</string>
+    <string name="stop_searching">Stop searching</string>
 
     <!-- PartyEnd -->
     <string name="party_again">Party Again?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="denied_permissions_msg">The partyq app uses Bluetooth and/or local Wifi to connect everyone in the party and exchange data. In order to accomplish this connection, partyq requires Wifi, Bluetooth, and (unintuitively) Location permissions. Please come back after granting the missing permissions in the Settings app or by retrying your last action.</string>
     <string name="no_spotify_premium_msg">We noticed that the Spotify account logged into your Spotify app isn\'t premium. The partyq app relies on the Spotify app to play specific songs and, unfortunately, Spotify free doesn\'t let you play specific songs at will (if you tried, it would instead play a random song). Please come back after logging into a Spotify Premium account in your Spotify app.</string>
     <string name="no_spotify_msg">The partyq app relies on the Spotify app to play music; if you don\'t have the Spotify app installed (and are logged in with a premium account) then you can\'t play any music! Please come back after installing and logging into the Spotify app on this device.</string>
+    <string name="spotify_crash_msg">Spotify and/or partyq\'s connections to Spotify has crashed. Without the connection to Spotify, you can\'t control what music is played. You will have to try starting the party over again, sorry!</string>
     <string name="got_it">got it</string>
     <string name="oops">OOPS!</string>
 </resources>


### PR DESCRIPTION
Extends party discovery timer duration to allow slower connections time to connect to a party. Also adds a button to stop searching for a party (so you don't have to wait out the whole timer to try another code).

closes #91 