### PR TITLE
Cleanup on leaveing party

### DIFF
--- a/app/src/main/java/com/niehusst/partyq/services/SpotifyPlayerService.kt
+++ b/app/src/main/java/com/niehusst/partyq/services/SpotifyPlayerService.kt
@@ -166,10 +166,15 @@ object SpotifyPlayerService {
      */
     fun disconnect() {
         // disconnecting doesn't actually stop the Spotify app from running and playing music
-        spotifyAppRemote?.let {
+        spotifyAppRemote?.let { appRemote ->
             // pause the song first so music doesn't keep playing after disconnect
-            pauseSong()
-            SpotifyAppRemote.disconnect(it)
+            appRemote.playerApi.pause().setResultCallback {
+                SpotifyAppRemote.disconnect(appRemote)
+            }.setErrorCallback {
+                Timber.e("Error pausing Spotify:\n$it")
+                // we have to disconnect anyway
+                SpotifyAppRemote.disconnect(appRemote)
+            }
         }
 
         spotifyAppRemote = null

--- a/app/src/main/java/com/niehusst/partyq/ui/partyActivity/PartyActivity.kt
+++ b/app/src/main/java/com/niehusst/partyq/ui/partyActivity/PartyActivity.kt
@@ -76,7 +76,8 @@ class PartyActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-//        disconnect(forced = false) // TODO: see if the behavior is any diff w/ and w/o this line
+        // clean up all our connected services
+        viewModel.resetAllServices(this)
         super.onDestroy()
     }
 


### PR DESCRIPTION
closes #83 
closes #70 

Cleans up services onDestroy() and pauses song before disconnecting from Spotify app remote (although that doesn't happen when PartyActivity is destroyed. Must be due to app losing ability to respond to callbacks?). 