### PR TITLE
Fix Spotify url link

### DIFF
--- a/app/src/main/java/com/niehusst/partyq/network/models/api/Album.kt
+++ b/app/src/main/java/com/niehusst/partyq/network/models/api/Album.kt
@@ -19,13 +19,13 @@ package com.niehusst.partyq.network.models.api
 import com.squareup.moshi.Json
 
 data class Album(
-    @Json(name = "album_type")
+    @field:Json(name = "album_type")
     val albumType: String,
     @Json(name = "artists")
     val artists: List<Artist>? = null,
-    @Json(name = "available_markets")
+    @field:Json(name = "available_markets")
     val availableMarkets: List<String>? = null,
-    @Json(name = "external_urls")
+    @field:Json(name = "external_urls")
     val externalUrls: ExternalUrls?,
     @Json(name = "href")
     val href: String,
@@ -35,11 +35,11 @@ data class Album(
     val images: List<Image>? = null,
     @Json(name = "name")
     val name: String,
-    @Json(name = "release_date")
+    @field:Json(name = "release_date")
     val releaseDate: String,
-    @Json(name = "release_date_precision")
+    @field:Json(name = "release_date_precision")
     val releaseDatePrecision: String,
-    @Json(name = "total_tracks")
+    @field:Json(name = "total_tracks")
     val totalTracks: Int,
     @Json(name = "type")
     val type: String,

--- a/app/src/main/java/com/niehusst/partyq/network/models/api/Artist.kt
+++ b/app/src/main/java/com/niehusst/partyq/network/models/api/Artist.kt
@@ -19,7 +19,7 @@ package com.niehusst.partyq.network.models.api
 import com.squareup.moshi.Json
 
 data class Artist(
-    @Json(name = "external_urls")
+    @field:Json(name = "external_urls")
     val externalUrls: ExternalUrls?,
     @Json(name = "href")
     val href: String,

--- a/app/src/main/java/com/niehusst/partyq/network/models/api/Item.kt
+++ b/app/src/main/java/com/niehusst/partyq/network/models/api/Item.kt
@@ -23,31 +23,31 @@ data class Item(
     val album: Album,
     @Json(name = "artists")
     val artists: List<Artist>? = null,
-    @Json(name = "available_markets")
+    @field:Json(name = "available_markets")
     val availableMarkets: List<String>? = null,
-    @Json(name = "disc_number")
+    @field:Json(name = "disc_number")
     val discNumber: Int,
-    @Json(name = "duration_ms")
+    @field:Json(name = "duration_ms")
     val durationMs: Int,
     @Json(name = "explicit")
     val explicit: Boolean,
-    @Json(name = "external_ids")
+    @field:Json(name = "external_ids")
     val externalIds: ExternalIds?,
-    @Json(name = "external_urls")
+    @field:Json(name = "external_urls")
     val externalUrls: ExternalUrls?,
     @Json(name = "href")
     val href: String,
     @Json(name = "id")
     val id: String,
-    @Json(name = "is_local")
+    @field:Json(name = "is_local")
     val isLocal: Boolean,
     @Json(name = "name")
     val name: String,
     @Json(name = "popularity")
     val popularity: Int,
-    @Json(name = "preview_url")
+    @field:Json(name = "preview_url")
     val previewUrl: String? = null,
-    @Json(name = "track_number")
+    @field:Json(name = "track_number")
     val trackNumber: Int,
     @Json(name = "type")
     val type: String,

--- a/app/src/main/java/com/niehusst/partyq/ui/nowPlaying/NowPlayingFragment.kt
+++ b/app/src/main/java/com/niehusst/partyq/ui/nowPlaying/NowPlayingFragment.kt
@@ -17,6 +17,7 @@
 package com.niehusst.partyq.ui.nowPlaying
 
 import android.os.Bundle
+import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -51,6 +52,7 @@ class NowPlayingFragment : Fragment() {
         binding.isHost = UserTypeService.isHost(requireContext())
         viewModel.currItem = QueueService.peekQueue()
         bindItem(viewModel.currItem)
+        binding.spotifyLink.movementMethod = LinkMovementMethod()
 
         QueueService.dataChangedTrigger.observe(viewLifecycleOwner, Observer {
             if (viewModel.isNewCurrItem()) {

--- a/app/src/main/res/layout-land/now_playing_fragment.xml
+++ b/app/src/main/res/layout-land/now_playing_fragment.xml
@@ -59,6 +59,7 @@
                 android:textColor="@color/onBackgroundColorLight"
                 android:textIsSelectable="true"
                 android:textAlignment="center"
+                android:autoLink="web"
                 app:layout_constraintBottom_toTopOf="@id/album_image"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/now_playing_fragment.xml
+++ b/app/src/main/res/layout/now_playing_fragment.xml
@@ -51,6 +51,7 @@
             android:textColor="@color/onBackgroundColorLight"
             android:textIsSelectable="true"
             android:textAlignment="center"
+            android:autoLink="web"
             app:layout_constraintBottom_toTopOf="@id/album_image"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
closes #115 

The problem was that Moshi was not respecting the `@Json(name="whatever")` decorator and would only try to parse exact matches of data class field name, leading to incorrect parsing failures and thus null fields.