### PR TITLE
Spotify stop recovery

### DIFF
--- a/app/src/main/java/com/niehusst/partyq/services/QueueService.kt
+++ b/app/src/main/java/com/niehusst/partyq/services/QueueService.kt
@@ -38,7 +38,6 @@ object QueueService {
             }
 
             // notify guests of updated data
-            // TODO: would a periodic batched approach be better? Even if we end up sending a lot of needless packets when data isn't updated?
             CommunicationService.sendUpdatedQueue(songQueue.toList())
         } else {
             CommunicationService.sendEnqueueRequest(item)

--- a/app/src/main/java/com/niehusst/partyq/services/SkipSongHandler.kt
+++ b/app/src/main/java/com/niehusst/partyq/services/SkipSongHandler.kt
@@ -16,8 +16,6 @@
 
 package com.niehusst.partyq.services
 
-import timber.log.Timber
-
 object SkipSongHandler {
 
     private var skipCount = 0
@@ -29,18 +27,10 @@ object SkipSongHandler {
     fun voteSkip() {
         // +1 to include the host in the count
         val numPartyGoers = CommunicationService.connectionEndpointIds.size + 1
-        Timber.e("BIGGYCHEESE skip vote registering")
+
         skipCount++
         if (skipCount > numPartyGoers / 2) {
-            Timber.e("BIGGYCHEESE skipping song")
-            // skip song
-            SpotifyPlayerService.skipSong {
-                // try playing queue head if skip fails
-                Timber.e("BIGGYCHEESE attempting to play song on skip fail")
-                QueueService.peekQueue()?.also { song ->
-                    SpotifyPlayerService.playSong(song.uri)
-                }
-            }
+            SpotifyPlayerService.skipSong()
 
             // clear registered votes for next song
             clearSkipCount()
@@ -48,8 +38,6 @@ object SkipSongHandler {
     }
 
     fun clearSkipCount() {
-        Timber.e("BIGGYCHEESE reseting count $skipCount")
         skipCount = 0
-        Timber.e("BIGGYCHEESE count now $skipCount")
     }
 }

--- a/app/src/main/java/com/niehusst/partyq/services/SkipSongHandler.kt
+++ b/app/src/main/java/com/niehusst/partyq/services/SkipSongHandler.kt
@@ -16,6 +16,8 @@
 
 package com.niehusst.partyq.services
 
+import timber.log.Timber
+
 object SkipSongHandler {
 
     private var skipCount = 0
@@ -27,11 +29,18 @@ object SkipSongHandler {
     fun voteSkip() {
         // +1 to include the host in the count
         val numPartyGoers = CommunicationService.connectionEndpointIds.size + 1
-
+        Timber.e("BIGGYCHEESE skip vote registering")
         skipCount++
         if (skipCount > numPartyGoers / 2) {
+            Timber.e("BIGGYCHEESE skipping song")
             // skip song
-            SpotifyPlayerService.skipSong()
+            SpotifyPlayerService.skipSong {
+                // try playing queue head if skip fails
+                Timber.e("BIGGYCHEESE attempting to play song on skip fail")
+                QueueService.peekQueue()?.also { song ->
+                    SpotifyPlayerService.playSong(song.uri)
+                }
+            }
 
             // clear registered votes for next song
             clearSkipCount()
@@ -39,6 +48,8 @@ object SkipSongHandler {
     }
 
     fun clearSkipCount() {
+        Timber.e("BIGGYCHEESE reseting count $skipCount")
         skipCount = 0
+        Timber.e("BIGGYCHEESE count now $skipCount")
     }
 }


### PR DESCRIPTION
closes #102 

Ultimately, the issue was that Spotify somehow missed the play song command sent via AppRemote, and was left trying to play a null song. Since no song was playing, apparently pause/resume will vacuously succeed (not triggering error callbacks), but skip would fail for some reason. 
This is currently being checked by fetching the SpotifyPlayer state and checking if the current Track is null. (checking this within `autoPlay` would be ideal, but for some reason, that's too early to pick up the failure, so we check in the resume function instead.